### PR TITLE
Layout tweaks and generation numbers

### DIFF
--- a/anxiety_of_conception_algorithm.ipynb
+++ b/anxiety_of_conception_algorithm.ipynb
@@ -929,6 +929,7 @@
     "        output_name=version_name,\n",
     "        part_1_items=part_1_items,\n",
     "        part_2_items=part_2_items,\n",
+    "        book_number=book_num,\n",
     "        debug=False,\n",
     "    )\n",
     "    print(book_num, end=\"...\")"

--- a/paratext/introduction.typ
+++ b/paratext/introduction.typ
@@ -1,3 +1,14 @@
+#let section_break() = box(
+  width: 100%,
+  height: 3em,
+  [
+    #set align(center)
+    #set align(horizon)
+    #set text(font: "DejaVu Sans Mono", size: 14pt)
+    ❋
+  ]
+)
+
 = Introduction
 
 I wrote about one hundred prose poems in the year before I gave birth to my child. And I wrote about one hundred in the year after.
@@ -8,7 +19,7 @@ I also wondered if, as time progressed and my experiences became distorted in my
 
 When developing the concept for this book, I wanted the reader to contribute to this integration of time and memory and experience. As readers come to the book (to any book really) they bring their own interpretation, distorting the book's ideas through a lens of their own. Your experiences with conception—whether of child or otherwise—will color your interpretation of my words. And then, if you read it again, or discuss it with a friend, or return to the book years later at your own momentous threshold, you change the book again, experiencing it and therefore making it anew.
 
-I wanted The Anxiety of Conception to physically enact the way books change over time. Thus, each printing of The Anxiety of Conception presents the poems in a new order, representing a step towards a new interpretation, one influenced by all the readers that came before. In the endless sequence of generations, you are reading number _____.
+I wanted The Anxiety of Conception to physically enact the way books change over time. Thus, each printing of The Anxiety of Conception presents the poems in a new order, representing a step towards a new interpretation, one influenced by all the readers that came before. In the endless sequence of generations, you are reading number %BOOK_NUMBER%.
 
 But if the order of the poems is to change with each printing, how was I to arrange them?
 

--- a/paratext/technical-notes.typ
+++ b/paratext/technical-notes.typ
@@ -1,4 +1,4 @@
-= Appendix
+= Technical notes
 
 == Calculating the distance between poems
 

--- a/part_a.txt
+++ b/part_a.txt
@@ -150,7 +150,7 @@ someone so wholly their mind lives on in your own.
 
 [102] \1907. "While throughout the lower grades of intelligence, concrete objects and acts are reproduced in thought, and the imagination is thus almost exclusively reminiscent, the further development of the power of conception implies a continually wider range of thoughts, more numerous and more varied and involved." Interstate Medical Journal November 906. Accessed via the Oxford English Dictionary.
 
-[103] 1650. "All evidence is conception..and all conception is imagination, and proceedeth from Sense." T. Hobbes, Humane Nature xi. 136. Accessed via the Oxford English Dictionary.
+[103] \1650. "All evidence is conception..and all conception is imagination, and proceedeth from Sense." T. Hobbes, Humane Nature xi. 136. Accessed via the Oxford English Dictionary.
 
 [105] Maybe everything I'm looking for is staying very still. When I pause I want to stay that way. Opposite of the puppy who will spin and spin in excitement and in the patches of stillness seems only to recoil and get ready to set himself back in motion. Am I a spring also? Vibrating with what could occur.
 

--- a/template.typ
+++ b/template.typ
@@ -36,6 +36,7 @@
   #set align(horizon)
   = The Anxiety of Conception
   == Katy Ilonka Gero
+  %BOOK_NUMBER% of ∞
 ]
 
 #pagebreak()
@@ -53,7 +54,9 @@
 
   For further permission requests, please contact the publisher.
 
-  ISBN XXXXXXXXXXXXXXXXXXXX
+  ISBN 978-1-7339515-4-8
+
+  Cover art by Noa Samson: noasamson.com
 
   Typeset using Typst and the Libertinus Serif font.
 
@@ -90,19 +93,29 @@
 #page[
   #set align(center)
   #set align(horizon)
-  #set text(size: 2em)
-  #smallcaps([The Anxiety of Conception])
+  #text(size: 2em)[
+    #smallcaps([The Anxiety of Conception])
+  ]
+
+  #text(size: 1.5em)[
+    $
+      %BOOK_NUMBER% \/ infinity
+    $
+  ]
 ]
 
-#pagebreak(to: "even")
+#pagebreak(to: "odd")
 #include("./dedication.typ")
 
-#pagebreak(to: "even")
+#pagebreak(to: "odd")
 #include("./epigraph.typ")
 
-#pagebreak()
+#pagebreak(to: "odd")
 #set page(numbering: "i")
 #include("./introduction.typ")
+
+#pagebreak(to: "even")
+#set page(numbering: none)
 
 // Part 1 title page
 #pagebreak(to: "odd")
@@ -119,6 +132,10 @@
 
 %PART_1%
 
+#pagebreak(to: "even")
+#pagebreak(to: "odd")
+#set page(numbering: "1")
+
 // Part 2 title page
 #page[
   #set align(center)
@@ -132,7 +149,7 @@
 
 #pagebreak()
 
-#include("./appendix.typ")
+#include("./technical-notes.typ")
 
 #pagebreak()
 


### PR DESCRIPTION
- Place epigraph, dedication, and part 1/2 title pages on right side
- Populate book number in paratext
- Fix section break appearance in introduction
- Rename appendix to "technical notes", including section title
- Fix appearance of "1650. ..." to not show as numbered list
- Add ISBN and cover artist to copyright page (that's the real ISBN now)