### PR TITLE
Prevent intro signature overflow

### DIFF
--- a/paratext/introduction.typ
+++ b/paratext/introduction.typ
@@ -1,6 +1,6 @@
 #let section_break() = box(
   width: 100%,
-  height: 3em,
+  height: 2em,
   [
     #set align(center)
     #set align(horizon)


### PR DESCRIPTION
It turns out that in versions >= 100, we get an overflow in the intro layout causing the signature portion at the end to flow to a new page. Unfortunately a few of these did already go to print, but we can fix it for future readers. The fix here is to simply shrink the "*" section dividers slightly. I confirmed this works, and have updated the print queue with these new versions.